### PR TITLE
Test and build with GitHub Actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -27,14 +27,14 @@ jobs:
     - name: Build packages
       run: |
         make package
-    - name: Build docs with sphinx
-      if: "matrix.python == '3.8'"
-      run: |
-        make docs
     - name: Run tests
       run: |
         pip install -e .
         make coverage
+    - name: Build docs with sphinx
+      if: "matrix.python == '3.8'"
+      run: |
+        make docs
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -33,6 +33,7 @@ jobs:
         make docs
     - name: Run tests
       run: |
+        pip install -e .
         make coverage
     - name: Upload packages
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -6,7 +6,7 @@ jobs:
   build_test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-20.04", "macos-latest"]
         python: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
@@ -27,12 +27,17 @@ jobs:
     - name: Build packages
       run: |
         make package
+    - name: Repair wheels
+      if: "matrix.os == 'ubuntu-20.04'"
+      run: |
+        pip install -U auditwheel patchelf
+        auditwheel repair --plat manylinux_2_31_x86_64 --wheel-dir dist dist/what_url-*linux*.whl
     - name: Run tests
       run: |
         pip install -e .
         make coverage
     - name: Build docs with sphinx
-      if: "matrix.python == '3.8' && matrix.os == 'ubuntu-latest'"
+      if: "matrix.python == '3.8' && matrix.os == 'ubuntu-20.04'"
       run: |
         make docs
     - name: Upload packages

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,39 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  build_test:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        make requirements
+    - name: Static analysis
+      if: "matrix.python == '3.8'"
+      run: |
+        make check
+    - name: Build docs with sphinx
+      if: "matrix.python == '3.8'"
+      run: |
+        make docs
+    - name: Build packages
+      run: |
+        make package
+    - name: Upload packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: what-url-packages
+        path: dist/*

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,13 +25,16 @@ jobs:
       if: "matrix.python == '3.8'"
       run: |
         make check
+    - name: Build packages
+      run: |
+        make package
     - name: Build docs with sphinx
       if: "matrix.python == '3.8'"
       run: |
         make docs
-    - name: Build packages
+    - name: Run tests
       run: |
-        make package
+        make coverage
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,8 +25,14 @@ jobs:
       run: |
         make check
     - name: Build packages
+      if: "matrix.os != 'windows-latest'"
       run: |
         make package
+    - name: Build packages (Windows)
+      if: "matrix.os == 'windows-latest'"
+      run: |
+        cl /c "what_url/ada.cpp" /std:c++17 /Fo "what_url/ada.o"
+        python -m build --no-isolation
     - name: Run tests
       run: |
         pip install -e .

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -6,7 +6,7 @@ jobs:
   build_test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
@@ -25,20 +25,14 @@ jobs:
       run: |
         make check
     - name: Build packages
-      if: "matrix.os != 'windows-latest'"
       run: |
         make package
-    - name: Build packages (Windows)
-      if: "matrix.os == 'windows-latest'"
-      run: |
-        cl.exe /c "what_url/ada.cpp" /std:c++17 /Fo "what_url/ada.o"
-        python -m build --no-isolation
     - name: Run tests
       run: |
         pip install -e .
         make coverage
     - name: Build docs with sphinx
-      if: "matrix.python == '3.8'"
+      if: "matrix.python == '3.8' && matrix.os == 'ubuntu-latest'"
       run: |
         make docs
     - name: Upload packages

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Build packages (Windows)
       if: "matrix.os == 'windows-latest'"
       run: |
-        cl /c "what_url/ada.cpp" /std:c++17 /Fo "what_url/ada.o"
+        cl.exe /c "what_url/ada.cpp" /std:c++17 /Fo "what_url/ada.o"
         python -m build --no-isolation
     - name: Run tests
       run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,7 +19,6 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
         make requirements
     - name: Static analysis
       if: "matrix.python == '3.8'"

--- a/MANIFEST.IN
+++ b/MANIFEST.IN
@@ -1,6 +1,0 @@
-include what_url/*.o
-include what_url/*.so
-include what_url/*.cpp
-include what_url/*.c
-include what_url/*.h
-include what_url/_ada_wrapper*

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,6 @@ clean:
 
 .PHONY: package
 package:
-	c++ -c "what_url/ada.cpp" -std="c++17" -o "what_url/ada.o"
+	c++ -c "what_url/ada.cpp" -fPIC -std="c++17" -o "what_url/ada.o"
 	python -m build --no-isolation
 	twine check dist/*

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ clean:
 
 .PHONY: package
 package:
-	c++ --version
 	c++ -c "what_url/ada.cpp" -fPIC -std="c++17" -o "what_url/ada.o"
 	python -m build --no-isolation
 	twine check dist/*

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,6 @@ clean:
 
 .PHONY: package
 package:
-	c++ -c "what_url/ada.cpp" -fPIC -std="c++17" -o "what_url/ada.o"
+	c++ -c "what_url/ada.cpp" -fPIC -std="c++17" -O2 -o "what_url/ada.o"
 	python -m build --no-isolation
 	twine check dist/*

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ clean:
 
 .PHONY: package
 package:
+	c++ --version
 	c++ -c "what_url/ada.cpp" -fPIC -std="c++17" -o "what_url/ada.o"
 	python -m build --no-isolation
 	twine check dist/*

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,10 +1,13 @@
 # What we want
+build==0.10.0
 black==23.3.0
 cffi==1.15.1
 coverage==7.2.5
 ruff==0.0.267
-twine==4.0.2
+setuptools==67.7.2
 Sphinx==7.0.0
+twine==4.0.2
+wheel==0.40.0
 
 # What we need
 alabaster==0.7.13
@@ -30,6 +33,7 @@ pathspec==0.11.1
 pkginfo==1.9.6
 platformdirs==3.5.1
 pycparser==2.21
+pyproject_hooks==1.0.0
 Pygments==2.15.1
 readme-renderer==37.3
 requests==2.30.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,14 @@ install_requires =
 exclude =
     tests
 
+[options.package_data]
+what_url =
+    *.c
+    *.cpp
+    *.o
+    *.so
+    *.h
+
 [coverage:run]
 include =
     what_url/**

--- a/what_url/ada.cpp
+++ b/what_url/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-05-15 12:09:38 -0400. Do not edit! */
+/* auto-generated on 2023-05-16 13:48:47 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */

--- a/what_url/ada.h
+++ b/what_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-05-15 12:09:38 -0400. Do not edit! */
+/* auto-generated on 2023-05-16 13:48:47 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -6484,14 +6484,14 @@ inline std::ostream &operator<<(std::ostream &out,
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.4.0"
+#define ADA_VERSION "2.4.1"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 4,
-  ADA_VERSION_REVISION = 0,
+  ADA_VERSION_REVISION = 1,
 };
 
 }  // namespace ada

--- a/what_url/ada_build.py
+++ b/what_url/ada_build.py
@@ -1,14 +1,17 @@
 from cffi import FFI
 from os.path import dirname, join
+from sys import platform
 
 file_dir = dirname(__file__)
+
+libraries = ['stdc++'] if platform == 'linux' else []
 
 ffi_builder = FFI()
 ffi_builder.set_source(
     'what_url._ada_wrapper',
     '# include "ada_c.h"',
     include_dirs=[file_dir],
-    libraries=['stdc++'],
+    libraries=libraries,
     extra_objects=[join(file_dir, 'ada.o')],
 )
 

--- a/what_url/ada_build.py
+++ b/what_url/ada_build.py
@@ -8,6 +8,7 @@ ffi_builder.set_source(
     'what_url._ada_wrapper',
     '# include "ada_c.h"',
     include_dirs=[file_dir],
+    libraries=['stdc++'],
     extra_objects=[join(file_dir, 'ada.o')],
 )
 


### PR DESCRIPTION
This PR introduces GitHub Actions for testing and building.

Wheels are built for Linux and Mac. The Linux wheels are treated with `auditwheel` to make them portable; they have not yet been tested. The Mac wheels have not been treated with `delocate` yet. I'm punting on Windows wheels for now.